### PR TITLE
chore: use u32 as index to array

### DIFF
--- a/src/poseidon/mod.nr
+++ b/src/poseidon/mod.nr
@@ -139,7 +139,7 @@ fn absorb<let T: u32, let N: u32, let X: u32, let O: u32>(
 
     for k in 0..msg.len() {
         // Add current block to state
-        state[capacity + i] += msg[k];
+        state[(capacity + i) as u32] += msg[k];
         i = i + 1;
         // Enough to absorb
         if i == rate {


### PR DESCRIPTION
# Description

Update array indexing to use u32 instead of Field,  the expected type in sort v0.3.0.
The issue was discovered while attempting to use sort v0.3.0 in noir-json-parser.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
