### PR TITLE
feat: remove cache in static length poseidon2

### DIFF
--- a/src/poseidon2.nr
+++ b/src/poseidon2.nr
@@ -85,9 +85,9 @@ impl Poseidon2 {
 
         // Always run final permutation unless we just completed a full chunk
         // still need to permute once if in_len is 0
-        if in_len == 0 | in_len % RATE != 0 {
-            state = crate::poseidon2_permutation(state, 4);
-        }
+        if (in_len == 0) | (in_len % RATE != 0) {
+            state = crate::poseidon2_permutation(state, 4)
+        };
 
         state[0]
     }


### PR DESCRIPTION
# Description

When message size is given, there is no need to use cache to track absorb vs squeeze.
## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
