### PR TITLE
fix: remove OOB read from cache and unnecessary zeroing in `perform_duplex` 

### DIFF
--- a/src/poseidon2.nr
+++ b/src/poseidon2.nr
@@ -132,6 +132,6 @@ impl Hasher for Poseidon2Hasher {
 
 impl Default for Poseidon2Hasher {
     fn default() -> Self {
-        Poseidon2Hasher { _state: @[] }
+        Poseidon2Hasher { _state: &[] }
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

The cache only has 3 elements, not 4. Also the zeroing of later elements is unnecessary as it will only be called when the cache is full.


## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
