### PR TITLE
fix: Make RATE no longer comptime

### DIFF
--- a/src/poseidon2.nr
+++ b/src/poseidon2.nr
@@ -1,7 +1,7 @@
 use std::default::Default;
 use std::hash::Hasher;
 
-comptime global RATE: u32 = 3;
+global RATE: u32 = 3;
 
 pub struct Poseidon2 {
     cache: [Field; 3],


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

The `RATE` global does not need to be comptime. This is causing errors with [future noir changes](https://github.com/noir-lang/noir/pull/11627) which require comptime globals to only be called in comptime contexts.

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
