### PR TITLE
fix(scripts): Fix unreliable port exits that causes racing conditions

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -15,7 +15,7 @@ trap cleanup EXIT
 
 # Build TypeScript first
 echo "Building TypeScript..."
-yarn --cwd "$project_dir" build
+yarn build
 
 # Start TypeScript RPC server in background
 echo "Starting TypeScript RPC server..."

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,6 +3,7 @@ set -eu
 
 export PORT="${PORT:-8095}"
 TS_SERVER_PID=""
+project_dir="$(cd "$(dirname "$0")/.." && pwd)"
 
 cleanup() {
     if [[ -n "$TS_SERVER_PID" ]]; then
@@ -14,11 +15,11 @@ trap cleanup EXIT
 
 # Build TypeScript first
 echo "Building TypeScript..."
-yarn build
+yarn --cwd "$project_dir" build
 
 # Start TypeScript RPC server in background
 echo "Starting TypeScript RPC server..."
-node dist/oracle_server.js &
+node "$project_dir/dist/oracle_server.js" &
 TS_SERVER_PID=$!
 
 # Wait for server to start
@@ -28,8 +29,6 @@ if ! kill -0 "$TS_SERVER_PID" 2>/dev/null; then
     echo "TypeScript RPC server failed to start" >&2
     exit 1
 fi
-
-project_dir="$(dirname "$0")/.."
 
 # Run the Noir tests with oracle resolver
 nargo --program-dir="$project_dir" test --oracle-resolver http://localhost:${PORT}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 set -eu
 
-export PORT=8095
+export PORT="${PORT:-8095}"
+TS_SERVER_PID=""
+
+cleanup() {
+    if [[ -n "$TS_SERVER_PID" ]]; then
+        kill "$TS_SERVER_PID" 2>/dev/null || true
+        wait "$TS_SERVER_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
 
 # Build TypeScript first
 echo "Building TypeScript..."
@@ -9,12 +18,16 @@ yarn build
 
 # Start TypeScript RPC server in background
 echo "Starting TypeScript RPC server..."
-yarn start &
+node dist/oracle_server.js &
 TS_SERVER_PID=$!
-trap 'kill $TS_SERVER_PID 2>/dev/null || true' EXIT
 
 # Wait for server to start
 sleep 2
+
+if ! kill -0 "$TS_SERVER_PID" 2>/dev/null; then
+    echo "TypeScript RPC server failed to start" >&2
+    exit 1
+fi
 
 project_dir="$(dirname "$0")/.."
 


### PR DESCRIPTION
## Problem Resolved

This came from running [`scripts/check-critical-libraries.sh`](https://github.com/noir-lang/noir/blob/master/scripts/check-critical-libraries.sh).
When oracle tests of _sha256_, _poseidon_, and _keccak256_ were ran consecutively, the same port 8095 they rely on were not freed up in time for the next tests to run on, ended up in failing oracles tests.

## Summary of Changes

Strengthen port cleanup, and add error for when RPC server fails to start.

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
